### PR TITLE
プラクティス「kaminari を使ってページング処理を実装する」の課題提出

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,5 @@ group :test do
 end
 
 gem 'carrierwave'
+
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -277,6 +289,7 @@ DEPENDENCIES
   i18n_generators
   importmap-rails
   jbuilder
+  kaminari
   puma (~> 5.0)
   rails (~> 7.0.4)
   rubocop-fjord

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,7 @@ class BooksController < ApplicationController
 
   # GET /books or /books.json
   def index
-    @books = Book.all
+    @books = Book.all.order(id: :asc).page(params[:page])
   end
 
   # GET /books/1 or /books/1.json

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -16,3 +16,5 @@
 <nav class="page-nav">
   <%= link_to t('views.common.new', name: Book.model_name.human.downcase), new_book_path %>
 </nav>
+
+<%= paginate @books %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 3
+end

--- a/config/locales/kaminari-ja.yml
+++ b/config/locales/kaminari-ja.yml
@@ -1,0 +1,17 @@
+ja:
+  views:
+    pagination:
+      first: "&laquo; 最初"
+      last: "最後 &raquo;"
+      previous: "&lsaquo; 前"
+      next: "次 &rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "%{entry_name}がありません"
+          one: "<b>一つの</b>%{entry_name}しか表示されていません"
+          other: "他<b>%{count}</b>個の%{entry_name}が表示されています"
+      more_pages:
+        display_entries: "<b>%{first}&nbsp;-&nbsp;%{last}</b> 全部<b>%{total}</b>個の%{entry_name}が表示されています"


### PR DESCRIPTION
# 概要

プラクティス「kaminari を使ってページング処理を実装する」の課題提出

# 詳細

kaminari によるページング処理の実装、及び日本語化を実施しました。

並び替えの順序については `id` カラムを指定し、常に一定の並び順になるようにしています。
また、日本語用ファイルについては `https://github.com/kaminari/kaminari/wiki/Internationalization-and-Locales` を参考に作成しています。

お手数おかけしますが、レビューを宜しくお願い致します🙇‍♂️